### PR TITLE
Matching interests

### DIFF
--- a/amplify/backend/function/joinFriendGroup/src/index.js
+++ b/amplify/backend/function/joinFriendGroup/src/index.js
@@ -190,6 +190,8 @@ async function fillGroupSet(userid, set) {
   );
 }
 
+const LIKED = "liked";
+const LOVED = "loved";
 // [QAPair], [QAPair] -> int
 function compatibilityScore(q1, q2) {
   console.log("Compatability Score");
@@ -199,7 +201,9 @@ function compatibilityScore(q1, q2) {
   const user2Responses = new Map(q2.map(i => [i.q,i.a]));
   let score = 0;
   for (const [q, a] of user1Responses) {
-    if (a === user2Responses.get(q)) score += 1;
+    if ((a === LIKED || a === LOVED) && (user2Responses.get(q) === LIKED || user2Responses.get(q) === LOVED)) {
+      score += 1;
+    }
   }
   return score;
 }


### PR DESCRIPTION
## Objective
grouping lambda now counts like, love or love, like as a +1 for the similarity score
(maybe love, love could be +2 or something)

Implements/Fixes CH####
concern is the duplication of the LIKED and LOVED constants in the lambda code and elsewhere

## Screenshots
## Testing instructions
*How can others test your code?*

## Checklist
- [ ] Added an objective for this PR
- [ ] Linked Clubhouse Ticket
- [ ] Added screenshots
- [ ] Added testing instructions
- [ ] Added appropriate label(s)
- [ ] Ensure all tests pass
- [ ] Verify changes work as expected in the deploy preview environment
- [ ] Removed all changes unrelated to this Pull Request
- [ ] Added any pre-emptive comments you'd like to discuss
