### PR TITLE
Mayank rastogi/verification error modal

### DIFF
--- a/src/screens/ConfirmEmailScreen.tsx
+++ b/src/screens/ConfirmEmailScreen.tsx
@@ -64,8 +64,9 @@ const ConfirmEmailScreen = ({
     console.log("Attempting email validation");
     setError([]);
     if (!confirmForm()) {
-      console.error(errors);
+      //console.error(errors);
       setErrorModal(true);
+      return;
     }
     try {
       await Auth.confirmSignUp(email, code);


### PR DESCRIPTION
## Objective
*A brief description of the objective of this pull request.*
 - Email verification page now shows up a modal that displays the errors while verifying the email confirmation code.

Implements/Fixes CH####
- setErrorModal(true) -> seeting the error modal to be true when confirmForm() is false.
- Displaying the error message on the error modal.

## Screenshots
![image](https://user-images.githubusercontent.com/62538173/144722046-1e15c720-cb78-4092-8bd6-d7dade4e6e17.png)
![image](https://user-images.githubusercontent.com/62538173/144722051-ce5ea784-94e2-4a15-82e4-3634bc063938.png)
![image](https://user-images.githubusercontent.com/62538173/144722056-d63167e1-5cbb-4041-a013-b414905ffab9.png)

## Testing instructions
*How can others test your code?*
- Sign up as a new user and either leave the verification code blank or enter an incorrect code.

## Checklist
- [x] Added an objective for this PR
- [x] Added screenshots
- [x] Added testing instructions
- [ ] Added appropriate label(s)
- [x] Ensure all tests pass
- [ ] Verify changes work as expected in the deploy preview environment
- [x] Removed all changes unrelated to this Pull Request
- [x] Added any pre-emptive comments you'd like to discuss
